### PR TITLE
Patch serialize-javascript RCE and DoS via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "sass": "^1.80.0",
     "tsx": "^4.21.0",
     "typescript": "^5.6.0"
+  },
+  "resolutions": {
+    "serialize-javascript": "^7.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8710,13 +8710,6 @@ radix3@^1.1.2:
   resolved "https://registry.yarnpkg.com/radix3/-/radix3-1.1.2.tgz#fd27d2af3896c6bf4bcdfab6427c69c2afc69ec0"
   integrity sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==
 
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
-
 range-parser@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -9202,7 +9195,7 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -9286,14 +9279,7 @@ send@^1.2.0:
     range-parser "^1.2.1"
     statuses "^2.0.2"
 
-serialize-javascript@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^7.0.3:
+serialize-javascript@^6.0.1, serialize-javascript@^7.0.3, serialize-javascript@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
   integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==


### PR DESCRIPTION
## Summary
- Adds a `resolutions` entry pinning `serialize-javascript` to `^7.0.5`, collapsing the previously-separate `^6.0.1`, `^7.0.3`, and `^7.0.5` ranges onto a single patched copy.
- Resolves Dependabot alerts #158 (high — RCE via `RegExp.flags` / `Date.prototype.toISOString`) and #179 (moderate — CPU exhaustion DoS).

## Why a resolution
The vulnerable `serialize-javascript@6.0.2` was a transitive dep: `workbox-build@7.4.0` → `@rollup/plugin-terser@0.4.4` → `serialize-javascript@^6.0.1`. Upstream hasn't bumped the terser plugin yet. `serialize-javascript` v7 is just a Node engine requirement bump (no API change), so forcing it is drop-in safe for the existing consumers.

## Test plan
- [x] `yarn install` succeeds; lockfile now resolves all three ranges to `7.0.5`.
- [x] `yarn build` completes cleanly (static build + nitro output).
- [ ] After merge, confirm Dependabot closes alerts #158 and #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)